### PR TITLE
Corrections

### DIFF
--- a/src/BinaryOperation.php
+++ b/src/BinaryOperation.php
@@ -7,7 +7,3 @@ interface BinaryOperation
     public function __invoke($x, $y);
 };
 
-interface TernaryOperation
-{
-    public function __invoke($x, $y, $z);
-};

--- a/src/TernaryOperation.php
+++ b/src/TernaryOperation.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Operations;
+
+interface TernaryOperation
+{
+    public function __invoke($x, $y, $z);
+};

--- a/tests/AddTest.php
+++ b/tests/AddTest.php
@@ -44,4 +44,12 @@ class AddTest extends TestCase
         $add = new Add();
         $add->__invoke(3, true);
     }
+
+    /** @test */
+    public function floatParameter()
+    {
+        $this->expectException(WrongTypeException::class);
+        $add = new Add();
+        $add->__invoke(3, 1.5);
+    }
 }

--- a/tests/SubtractTest.php
+++ b/tests/SubtractTest.php
@@ -48,7 +48,14 @@ class SubtractTest extends TestCase
         $this->expectException(WrongTypeException::class);
         $subtract = new Subtract();
         $subtract->__invoke(3, true);
-    
+    }
+
+    /** @test */
+    public function floatParameter()
+    {
+        $this->expectException(WrongTypeException::class);
+        $add = new Subtract();
+        $add->__invoke(3, 1.5);
     }
 
 }


### PR DESCRIPTION
Añado una corrección que hacía que CompositionTest no se pudiera ejecutar correctamente. Consiste en no utilizar más de una definición de clase/interfaz por fichero. En otro caso, el autoloader no funcionaría, como ocurre en tu solución.

Al mismo tiempo añado un caso más a los tests AddTest y SubtractTest para que te puedas orientar al utilizar declaraciones de tipos, como pretendía en un principio, en las clases que fueran necesarias.